### PR TITLE
fix: 修复litserve_worker中accelerator 设置为auto时,默认setup函数的device一直为cpu的问题.

### DIFF
--- a/backend/start_all.py
+++ b/backend/start_all.py
@@ -309,7 +309,7 @@ def main():
         "--accelerator",
         type=str,
         default="auto",
-        choices=["auto", "cuda", "cpu", "mps"],
+        choices=["auto", "cuda", "cpu"],
         help="加速器类型 (默认: auto，自动检测)",
     )
     parser.add_argument("--workers-per-device", type=int, default=1, help="每个GPU的worker数量 (默认: 1)")


### PR DESCRIPTION
issue:  https://github.com/magicyuan876/mineru-tianshu/issues/19

bug 原因: 

当 litserve 的 accelerator 设置为auto时, setup函数的device总是为cpu. 
当 accelerator = auto, litserve 调用 _choose_auto_accelerator方法进行具体的配置推断
https://github.com/Lightning-AI/LitServe/blob/41607f10ed63891dc3032e102308b4c873716817/src/litserve/connector.py#L72-L76
在_choose_auto_accelerator方法中会检查是否已经引入了pytorch, 如果没有就return  cpu
因此, 目前setup函数在触发时的传入参数总是device = cpu

导致 https://github.com/magicyuan876/mineru-tianshu/blob/5b87cd1f9eddb3c5d0dd034e647784423254e4a7/backend/litserve_worker.py#L181C1-L190C22
环境变量配置失效, 最终模型服务会启动在cuda:0 设备上. 



fix  方法: 

由于 pytorch的引入必须晚于CUDA_VISIBLE_DEVICES设置的限制
通过检查是否安装pytorch来推断auto设置是否为cuda. 