### PR TITLE
fix(task): 支持取消 pending/processing/paused 状态的任务

### DIFF
--- a/backend/api_server.py
+++ b/backend/api_server.py
@@ -576,6 +576,26 @@ async def retry_task(task_id: str, current_user: User = Depends(get_current_acti
     raise HTTPException(status_code=404, detail="Task not found")
 
 
+@router.post("/tasks/{task_id}/cancel", tags=["任务管理"])
+async def cancel_task_endpoint(task_id: str, current_user: User = Depends(get_current_active_user)):
+    """
+    取消任务：仅对 pending / processing / paused 状态的任务生效
+    """
+    task = db.get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    # 🚨 修复属性名称错误
+    if not current_user.has_permission(Permission.TASK_DELETE_ALL):
+        if task.get("user_id") != current_user.user_id:
+            raise HTTPException(status_code=403, detail="Permission denied")
+
+    if db.cancel_task(task_id):
+        return {"success": True, "message": "Task cancelled"}
+
+    raise HTTPException(status_code=409, detail="Task cannot be cancelled (must be in pending/processing/paused status)")
+
+
 @router.post("/tasks/{task_id}/pause", tags=["任务管理"])
 async def pause_task_endpoint(task_id: str, current_user: User = Depends(get_current_active_user)):
     """

--- a/backend/api_server.py
+++ b/backend/api_server.py
@@ -593,7 +593,9 @@ async def cancel_task_endpoint(task_id: str, current_user: User = Depends(get_cu
     if db.cancel_task(task_id):
         return {"success": True, "message": "Task cancelled"}
 
-    raise HTTPException(status_code=409, detail="Task cannot be cancelled (must be in pending/processing/paused status)")
+    raise HTTPException(
+        status_code=409, detail="Task cannot be cancelled (must be in pending/processing/paused status)"
+    )
 
 
 @router.post("/tasks/{task_id}/pause", tags=["任务管理"])

--- a/backend/task_db.py
+++ b/backend/task_db.py
@@ -836,6 +836,27 @@ class TaskDB:
             )
             return cursor.rowcount > 0
 
+    def cancel_task(self, task_id: str) -> bool:
+        """
+        取消任务：将 pending/processing/paused 状态的任务标记为 cancelled。
+        - 已取消的任务不会被打回 pending，也不会被调度器再次派发
+        - 正在处理的任务由 worker 在完成/失败时根据状态机自动跳过（completed/failed 仅对 processing 生效）
+        """
+        with self.get_cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE tasks
+                SET status = 'cancelled',
+                    started_at = NULL,
+                    completed_at = CURRENT_TIMESTAMP,
+                    worker_id = NULL
+                WHERE task_id = ?
+                AND status IN ('pending', 'processing', 'paused')
+                """,
+                (task_id,),
+            )
+            return cursor.rowcount > 0
+
     def pause_task(self, task_id: str) -> bool:
         """
         暂停任务：仅允许暂停处于 pending（排队中）的任务

--- a/frontend/src/api/taskApi.ts
+++ b/frontend/src/api/taskApi.ts
@@ -98,10 +98,10 @@ export async function getTaskStatus(
 }
 
 /**
- * 取消任务
+ * 取消任务 (仅 pending/processing/paused 状态有效，区别于彻底删除)
  */
 export async function cancelTask(taskId: string): Promise<ApiResponse> {
-  const response = await apiClient.delete<ApiResponse>(`/api/v1/tasks/${taskId}`)
+  const response = await apiClient.post<ApiResponse>(`/api/v1/tasks/${taskId}/cancel`)
   return response.data
 }
 

--- a/frontend/src/views/ApiDocsScalar.vue
+++ b/frontend/src/views/ApiDocsScalar.vue
@@ -72,7 +72,7 @@ const apiTranslations: Record<string, string> = {
   '需要认证。用户只能查看自己的任务，管理员可以查看所有任务。': 'Requires authentication. Users can only view their own tasks, administrators can view all tasks.',
   '当任务完成时，会自动返回解析后的内容（data 字段）': 'When the task is completed, the parsed content will be automatically returned (data field)',
 
-  '取消任务（仅限 pending 状态）': 'Cancel Task (pending status only)',
+  '取消任务（仅限 pending/processing/paused 状态）': 'Cancel Task (pending/processing/paused status only)',
   '需要认证。用户只能取消自己的任务，管理员可以取消任何任务。': 'Requires authentication. Users can only cancel their own tasks, administrators can cancel any task.',
 
   // 队列管理

--- a/frontend/src/views/TaskDetail.vue
+++ b/frontend/src/views/TaskDetail.vue
@@ -12,6 +12,10 @@
 
       <div class="flex items-center gap-3">
         <template v-if="task">
+            <button v-if="['pending', 'processing', 'paused'].includes(task.status)" @click="initiateAction('cancel')" :disabled="actionLoading" class="btn btn-white text-gray-600 border-gray-200 hover:bg-red-50 hover:text-red-600 hover:border-red-200 btn-sm flex items-center shadow-sm transition-all disabled:opacity-50" title="取消任务（保留任务记录）">
+              <XCircle :class="{'animate-pulse': actionLoading && currentAction === 'cancel'}" class="w-4 h-4 mr-1.5" />
+              <span>取消任务</span>
+            </button>
             <button v-if="task.status === 'failed'" @click="initiateAction('retry')" :disabled="actionLoading" class="btn btn-white text-blue-600 border-gray-200 hover:bg-blue-50 btn-sm flex items-center shadow-sm transition-all disabled:opacity-50">
               <RotateCw :class="{'animate-spin': actionLoading && currentAction === 'retry'}" class="w-4 h-4 mr-1.5" />
               <span>重试任务</span>
@@ -147,7 +151,7 @@ import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useTaskStore } from '@/stores'
-import { ArrowLeft, AlertCircle, RefreshCw, FileText, Columns, Download, RotateCw, Eraser, Pause, Image, Table, Trash2 } from 'lucide-vue-next'
+import { ArrowLeft, AlertCircle, RefreshCw, FileText, Columns, Download, RotateCw, Eraser, Pause, Image, Table, Trash2, XCircle } from 'lucide-vue-next'
 import StatusBadge from '@/components/StatusBadge.vue'
 import LoadingSpinner from '@/components/LoadingSpinner.vue'
 import MarkdownViewer from '@/components/MarkdownViewer.vue'
@@ -319,9 +323,9 @@ const showConfirm = ref(false)
 const confirmTitle = ref('')
 const confirmMessage = ref('')
 const confirmType = ref<'info' | 'warning' | 'danger'>('info')
-const currentAction = ref<'retry' | 'clearCache' | 'delete' | null>(null)
+const currentAction = ref<'retry' | 'clearCache' | 'delete' | 'cancel' | null>(null)
 
-function initiateAction(action: 'retry' | 'clearCache' | 'delete') {
+function initiateAction(action: 'retry' | 'clearCache' | 'delete' | 'cancel') {
   currentAction.value = action
   if (action === 'retry') {
     confirmTitle.value = '重试任务'; confirmMessage.value = '确定重试吗？'; confirmType.value = 'info'
@@ -329,6 +333,8 @@ function initiateAction(action: 'retry' | 'clearCache' | 'delete') {
     confirmTitle.value = '清理缓存'; confirmMessage.value = '确定清理吗？'; confirmType.value = 'warning'
   } else if (action === 'delete') {
     confirmTitle.value = '删除任务'; confirmMessage.value = '彻底删除该任务及文件？不可恢复。'; confirmType.value = 'danger'
+  } else if (action === 'cancel') {
+    confirmTitle.value = '取消任务'; confirmMessage.value = '确定取消该任务吗？已产生的处理结果将被保留。'; confirmType.value = 'warning'
   }
   showConfirm.value = true
 }
@@ -343,6 +349,8 @@ async function executeAction() {
       await taskStore.clearTaskCache(taskId.value); await refreshTask();
     } else if (currentAction.value === 'delete') {
       await taskStore.deleteTask(taskId.value); router.back();
+    } else if (currentAction.value === 'cancel') {
+      await taskStore.cancelTask(taskId.value); await refreshTask();
     }
   } catch (err: any) { error.value = err.message || 'Action failed' }
   finally { actionLoading.value = false; currentAction.value = null }


### PR DESCRIPTION
## 概述

修复 issue #65:「处理中」的任务不能取消。任务出错(如 OOM)后一直卡在 `processing` 状态,用户无法取消或重新开始,只能等调度器默认 60 分钟超时重置。

## 根因

- 前端 `cancelTask` 实际调用的是 `DELETE /tasks/{task_id}` —— 这是**彻底删除**任务记录和文件,不是取消语义,且对 processing 任务没有任何即时处理。
- 后端没有取消语义的 API;`task_db.update_task_status` 中虽有 `cancelled` 分支,但没有任何代码路径能产生该状态。

## 改动内容

### 后端
- `backend/task_db.py`:新增 `TaskDB.cancel_task()`,将 `pending` / `processing` / `paused` 状态的任务置为 `cancelled`(清空 `worker_id`/`started_at`,写入 `completed_at`)。
  - 已结束任务(`completed`/`failed`/`cancelled`)不可取消,返回 false。
  - 状态机保护:取消后 worker 迟到的 `completed`/`failed` 上报因 `WHERE status='processing'` 而失效,任务保持 `cancelled`。
  - 调度器 `reset_stale_tasks` 仅匹配 `processing`,不会把已取消任务打回 `pending`。
- `backend/api_server.py`:新增 `POST /tasks/{task_id}/cancel` 端点,权限模型与 `retry`/`pause` 一致(本人或 `TASK_DELETE_ALL`),不可取消时返回 409。

### 前端
- `frontend/src/api/taskApi.ts`:`cancelTask` 改为调用 `POST /tasks/{task_id}/cancel`(不再误用 DELETE 删除任务)。
- `frontend/src/views/TaskDetail.vue`:任务详情页为 `pending`/`processing`/`paused` 任务增加「取消任务」按钮(带确认对话框)。
- `frontend/src/views/ApiDocsScalar.vue`:同步更新取消接口的中英文说明。
- `TaskList.vue` 原有的取消/批量取消按钮自动获得正确语义,无需改动。

## 验证

- 后端:`py_compile` 通过;内存 SQLite 单测覆盖 5 个场景全部通过(processing/pending 可取消、completed/cancelled 不可取消、worker 迟到上报不覆盖取消状态)。
- 前端:`npm run build`(tsc + vite)构建成功。

Closes #65